### PR TITLE
Bullet Power Up Not Resetting 

### DIFF
--- a/playerCar.py
+++ b/playerCar.py
@@ -60,3 +60,6 @@ class PlayerCar(pygame.sprite.Sprite):
                 self.lastBulletTime = current_time
                 self.bulletSound.play()
                 self.bulletAmount -=1
+                if self.bulletAmount <= 0:
+                    self.bulletsActive = False
+                    self.bulletAmount = 20


### PR DESCRIPTION
The bullet power up wasnt resetting when the amount of bullets was 0. Instead it kept on like if the power up was still active even though it didn't do anything. Fixed that on this commit. 