### PR TITLE
Screen scaler bug fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ else:
     joystick = None
 
 screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
-scaler = GameScaler(c.game_width, c.game_height, screen)
+scaler = GameScaler(screen.get_width(), screen.get_height(), screen) # Use the actual screen dimensions for the scaler :3
 game_surface = pygame.Surface((c.game_width, c.game_height))
 
 if __name__ == "__main__":


### PR DESCRIPTION
The game was not properly centered on different screen sizes because `GameScaler` was initialized using `c.game_width` and `c.game_height`. I changed it to use the actual screen size with:

```python
scaler = GameScaler(screen.get_width(), screen.get_height(), screen)
```

This ensures proper scaling and centering regardless of the screen resolution.